### PR TITLE
Disable PHY 2mbps (and rename)

### DIFF
--- a/config/totem.conf
+++ b/config/totem.conf
@@ -1,5 +1,8 @@
 CONFIG_ZMK_USB_LOGGING=n
-CONFIG_ZMK_KEYBOARD_NAME="KBHTotem"
+CONFIG_ZMK_KEYBOARD_NAME="Totem"
+
+# disable phy 2mbps (https://zmk.dev/docs/troubleshooting/connection-issues)
+CONFIG_BT_CTLR_PHY_2M=n
 
 CONFIG_ZMK_POINTING=y
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y


### PR DESCRIPTION
Troubleshooting connection problems.

Appears for connection but fails on Mac. Doesn't even appear on iMac.